### PR TITLE
Add bazel rules fuzzing

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -288,12 +288,6 @@ build:asan-fuzzer --copt=-fno-omit-frame-pointer
 # Remove UBSAN halt_on_error to avoid crashing on protobuf errors.
 build:asan-fuzzer --test_env=UBSAN_OPTIONS=print_stacktrace=1
 
-build:asan-libfuzzer --action_env=CC=/opt/llvm/bin/clang
-build:asan-libfuzzer --action_env=CXX=/opt/llvm/bin/clang++
-build:asan-libfuzzer --linkopt=-fsanitize=fuzzer,address
-build:asan-libfuzzer --copt=-fsanitize=fuzzer,address
-build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
-
 # Fuzzing without ASAN. This is useful for profiling fuzzers without any ASAN artifacts.
 build:plain-fuzzer --define=FUZZING_ENGINE=libfuzzer
 build:plain-fuzzer --define ENVOY_CONFIG_ASAN=1

--- a/.bazelrc
+++ b/.bazelrc
@@ -294,6 +294,16 @@ build:plain-fuzzer --define ENVOY_CONFIG_ASAN=1
 build:plain-fuzzer --copt=-fsanitize=fuzzer-no-link
 build:plain-fuzzer --linkopt=-fsanitize=fuzzer-no-link
 
+# Common fuzzing flags. To be only used by other configs.
+build:_fuzzer_common --config=clang
+build:_fuzzer_common --copt=-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+
+# Flags for Clang with ASAN and libfuzzer.
+build:asan-libfuzzer --config=_fuzzer_common
+build:asan-libfuzzer --linkopt=-fsanitize=fuzzer,address
+build:asan-libfuzzer --copt=-fsanitize=fuzzer,address
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
+
 # Compile database generation config
 build:compdb --build_tag_filters=-nocompdb
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -288,6 +288,12 @@ build:asan-fuzzer --copt=-fno-omit-frame-pointer
 # Remove UBSAN halt_on_error to avoid crashing on protobuf errors.
 build:asan-fuzzer --test_env=UBSAN_OPTIONS=print_stacktrace=1
 
+build:asan-libfuzzer --action_env=CC=/opt/llvm/bin/clang
+build:asan-libfuzzer --action_env=CXX=/opt/llvm/bin/clang++
+build:asan-libfuzzer --linkopt=-fsanitize=fuzzer,address
+build:asan-libfuzzer --copt=-fsanitize=fuzzer,address
+build:asan-libfuzzer --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing//fuzzing/engines:libfuzzer
+
 # Fuzzing without ASAN. This is useful for profiling fuzzers without any ASAN artifacts.
 build:plain-fuzzer --define=FUZZING_ENGINE=libfuzzer
 build:plain-fuzzer --define ENVOY_CONFIG_ASAN=1

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -4,7 +4,7 @@ load("@envoy_build_tools//toolchains:rbe_toolchains_config.bzl", "rbe_toolchains
 load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict", "custom_exec_properties")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
-load("@bazel_rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
 load("@fuzzing_py_deps//:requirements.bzl", fuzzing_pip_install = "pip_install")
 load("@upb//bazel:repository_defs.bzl", upb_bazel_version_repository = "bazel_version_repository")
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -4,6 +4,8 @@ load("@envoy_build_tools//toolchains:rbe_toolchains_config.bzl", "rbe_toolchains
 load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict", "custom_exec_properties")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
+load("@bazel_rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+load("@fuzzing_py_deps//:requirements.bzl", fuzzing_pip_install = "pip_install")
 load("@upb//bazel:repository_defs.bzl", upb_bazel_version_repository = "bazel_version_repository")
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")
 load("@io_bazel_rules_rust//:workspace.bzl", "bazel_version")
@@ -29,6 +31,8 @@ def envoy_dependency_imports(go_version = GO_VERSION):
     bazel_version(name = "bazel_version")
     upb_bazel_version_repository(name = "upb_bazel_version")
     antlr_dependencies(472)
+    rules_fuzzing_dependencies()
+    fuzzing_pip_install()
 
     custom_exec_properties(
         name = "envoy_large_machine_exec_property",

--- a/bazel/dependency_imports.bzl
+++ b/bazel/dependency_imports.bzl
@@ -4,7 +4,7 @@ load("@envoy_build_tools//toolchains:rbe_toolchains_config.bzl", "rbe_toolchains
 load("@bazel_toolchains//rules/exec_properties:exec_properties.bzl", "create_rbe_exec_properties_dict", "custom_exec_properties")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
-load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
+load("@bazel_rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")
 load("@fuzzing_py_deps//:requirements.bzl", fuzzing_pip_install = "pip_install")
 load("@upb//bazel:repository_defs.bzl", upb_bazel_version_repository = "bazel_version_repository")
 load("@io_bazel_rules_rust//rust:repositories.bzl", "rust_repositories")

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -4,7 +4,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 # DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
 # Envoy test targets. This includes both test library and test binary targets.
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@bazel_rules_fuzzing//fuzzing:cc_deps.bzl", "cc_fuzz_test")
+load("@rules_fuzzing//fuzzing:cc_deps.bzl", "cc_fuzz_test")
 load(":envoy_binary.bzl", "envoy_cc_binary")
 load(":envoy_library.bzl", "tcmalloc_external_deps")
 load(
@@ -109,35 +109,35 @@ def envoy_cc_fuzz_test(
         tags = tags,
         **kwargs
     )
-    cc_test(
-        name = name,
-        copts = fuzz_copts + envoy_copts("@envoy", test = True),
-        linkopts = _envoy_test_linkopts() + select({
-            "@envoy//bazel:libfuzzer": ["-fsanitize=fuzzer"],
-            "//conditions:default": [],
-        }),
-        linkstatic = envoy_linkstatic(),
-        args = select({
-            "@envoy//bazel:libfuzzer_coverage": ["$(locations %s)" % corpus_name],
-            "@envoy//bazel:libfuzzer": [],
-            "//conditions:default": ["$(locations %s)" % corpus_name],
-        }),
-        data = [corpus_name],
-        # No fuzzing on macOS or Windows
-        deps = select({
-            "@envoy//bazel:apple": [repository + "//test:dummy_main"],
-            "@envoy//bazel:windows_x86_64": [repository + "//test:dummy_main"],
-            "@envoy//bazel:libfuzzer": [
-                ":" + test_lib_name,
-            ],
-            "//conditions:default": [
-                ":" + test_lib_name,
-                repository + "//test/fuzz:main",
-            ],
-        }),
-        size = size,
-        tags = ["fuzz_target"] + tags,
-    )
+    # cc_test(
+    #     name = name,
+    #     copts = fuzz_copts + envoy_copts("@envoy", test = True),
+    #     linkopts = _envoy_test_linkopts() + select({
+    #         "@envoy//bazel:libfuzzer": ["-fsanitize=fuzzer"],
+    #         "//conditions:default": [],
+    #     }),
+    #     linkstatic = envoy_linkstatic(),
+    #     args = select({
+    #         "@envoy//bazel:libfuzzer_coverage": ["$(locations %s)" % corpus_name],
+    #         "@envoy//bazel:libfuzzer": [],
+    #         "//conditions:default": ["$(locations %s)" % corpus_name],
+    #     }),
+    #     data = [corpus_name],
+    #     # No fuzzing on macOS or Windows
+    #     deps = select({
+    #         "@envoy//bazel:apple": [repository + "//test:dummy_main"],
+    #         "@envoy//bazel:windows_x86_64": [repository + "//test:dummy_main"],
+    #         "@envoy//bazel:libfuzzer": [
+    #             ":" + test_lib_name,
+    #         ],
+    #         "//conditions:default": [
+    #             ":" + test_lib_name,
+    #             repository + "//test/fuzz:main",
+    #         ],
+    #     }),
+    #     size = size,
+    #     tags = ["fuzz_target"] + tags,
+    # )
 
     # This target exists only for
     # https://github.com/google/oss-fuzz/blob/master/projects/envoy/build.sh. It won't yield

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -4,7 +4,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 # DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
 # Envoy test targets. This includes both test library and test binary targets.
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@rules_fuzzing//fuzzing:cc_deps.bzl", "cc_fuzz_test")
+load("@bazel_rules_fuzzing//fuzzing:cc_deps.bzl", "cc_fuzz_test")
 load(":envoy_binary.bzl", "envoy_cc_binary")
 load(":envoy_library.bzl", "tcmalloc_external_deps")
 load(
@@ -109,35 +109,35 @@ def envoy_cc_fuzz_test(
         tags = tags,
         **kwargs
     )
-    # cc_test(
-    #     name = name,
-    #     copts = fuzz_copts + envoy_copts("@envoy", test = True),
-    #     linkopts = _envoy_test_linkopts() + select({
-    #         "@envoy//bazel:libfuzzer": ["-fsanitize=fuzzer"],
-    #         "//conditions:default": [],
-    #     }),
-    #     linkstatic = envoy_linkstatic(),
-    #     args = select({
-    #         "@envoy//bazel:libfuzzer_coverage": ["$(locations %s)" % corpus_name],
-    #         "@envoy//bazel:libfuzzer": [],
-    #         "//conditions:default": ["$(locations %s)" % corpus_name],
-    #     }),
-    #     data = [corpus_name],
-    #     # No fuzzing on macOS or Windows
-    #     deps = select({
-    #         "@envoy//bazel:apple": [repository + "//test:dummy_main"],
-    #         "@envoy//bazel:windows_x86_64": [repository + "//test:dummy_main"],
-    #         "@envoy//bazel:libfuzzer": [
-    #             ":" + test_lib_name,
-    #         ],
-    #         "//conditions:default": [
-    #             ":" + test_lib_name,
-    #             repository + "//test/fuzz:main",
-    #         ],
-    #     }),
-    #     size = size,
-    #     tags = ["fuzz_target"] + tags,
-    # )
+    cc_test(
+        name = name,
+        copts = fuzz_copts + envoy_copts("@envoy", test = True),
+        linkopts = _envoy_test_linkopts() + select({
+            "@envoy//bazel:libfuzzer": ["-fsanitize=fuzzer"],
+            "//conditions:default": [],
+        }),
+        linkstatic = envoy_linkstatic(),
+        args = select({
+            "@envoy//bazel:libfuzzer_coverage": ["$(locations %s)" % corpus_name],
+            "@envoy//bazel:libfuzzer": [],
+            "//conditions:default": ["$(locations %s)" % corpus_name],
+        }),
+        data = [corpus_name],
+        # No fuzzing on macOS or Windows
+        deps = select({
+            "@envoy//bazel:apple": [repository + "//test:dummy_main"],
+            "@envoy//bazel:windows_x86_64": [repository + "//test:dummy_main"],
+            "@envoy//bazel:libfuzzer": [
+                ":" + test_lib_name,
+            ],
+            "//conditions:default": [
+                ":" + test_lib_name,
+                repository + "//test/fuzz:main",
+            ],
+        }),
+        size = size,
+        tags = ["fuzz_target"] + tags,
+    )
 
     # This target exists only for
     # https://github.com/google/oss-fuzz/blob/master/projects/envoy/build.sh. It won't yield

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -4,7 +4,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 # DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
 # Envoy test targets. This includes both test library and test binary targets.
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
-load("@bazel_rules_fuzzing//fuzzing:cc_deps.bzl", "cc_fuzz_test")
+load("@rules_fuzzing//fuzzing:cc_deps.bzl", "cc_fuzz_test")
 load(":envoy_binary.bzl", "envoy_cc_binary")
 load(":envoy_library.bzl", "tcmalloc_external_deps")
 load(

--- a/bazel/envoy_test.bzl
+++ b/bazel/envoy_test.bzl
@@ -4,6 +4,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 # DO NOT LOAD THIS FILE. Load envoy_build_system.bzl instead.
 # Envoy test targets. This includes both test library and test binary targets.
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@bazel_rules_fuzzing//fuzzing:cc_deps.bzl", "cc_fuzz_test")
 load(":envoy_binary.bzl", "envoy_cc_binary")
 load(":envoy_library.bzl", "tcmalloc_external_deps")
 load(
@@ -150,6 +151,14 @@ def envoy_cc_fuzz_test(
         testonly = 1,
         deps = [":" + test_lib_name],
         tags = ["manual"] + tags,
+    )
+
+    cc_fuzz_test(
+        name = name + "_experimental",
+        corpus = tar_src,
+        deps = [":" + test_lib_name],
+        size = size,
+        tags = ["fuzz_target"] + tags,
     )
 
 # Envoy C++ test targets should be specified with this function.

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -168,7 +168,7 @@ def envoy_dependencies(skip_targets = []):
     external_http_archive("com_github_google_flatbuffers")
     external_http_archive("bazel_toolchains")
     external_http_archive("bazel_compdb")
-    external_http_archive("bazel_rules_fuzzing")
+    external_http_archive("rules_fuzzing")
     external_http_archive("envoy_build_tools")
     external_http_archive("rules_cc")
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -168,7 +168,12 @@ def envoy_dependencies(skip_targets = []):
     external_http_archive("com_github_google_flatbuffers")
     external_http_archive("bazel_toolchains")
     external_http_archive("bazel_compdb")
-    external_http_archive("bazel_rules_fuzzing")
+
+    # external_http_archive("bazel_rules_fuzzing")
+    native.local_repository(
+        name = "rules_fuzzing",
+        path = "../rules_fuzzing",
+    )
     external_http_archive("envoy_build_tools")
     external_http_archive("rules_cc")
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -168,6 +168,7 @@ def envoy_dependencies(skip_targets = []):
     external_http_archive("com_github_google_flatbuffers")
     external_http_archive("bazel_toolchains")
     external_http_archive("bazel_compdb")
+    external_http_archive("bazel_rules_fuzzing")
     external_http_archive("envoy_build_tools")
     external_http_archive("rules_cc")
 

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -168,12 +168,7 @@ def envoy_dependencies(skip_targets = []):
     external_http_archive("com_github_google_flatbuffers")
     external_http_archive("bazel_toolchains")
     external_http_archive("bazel_compdb")
-
-    # external_http_archive("bazel_rules_fuzzing")
-    native.local_repository(
-        name = "rules_fuzzing",
-        path = "../rules_fuzzing",
-    )
+    external_http_archive("bazel_rules_fuzzing")
     external_http_archive("envoy_build_tools")
     external_http_archive("rules_cc")
 

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -8,6 +8,11 @@ def _python_deps():
     pip_repositories()
 
     pip3_import(
+        name = "fuzzing_py_deps",
+        requirements = "@rules_fuzzing//fuzzing:requirements.txt",
+    )
+
+    pip3_import(
         name = "config_validation_pip3",
         requirements = "@envoy//tools/config_validation:requirements.txt",
         extra_pip_args = ["--require-hashes"],
@@ -96,10 +101,6 @@ def _python_deps():
         # version = "1.15.0",
         # release_date = "2020-05-21"
         # use_category = ["test"],
-    )
-    pip3_import(
-        name = "fuzzing_py_deps",
-        requirements = "@bazel_rules_fuzzing//fuzzing:requirements.txt",
     )
 
 # Envoy deps that rely on a first stage of dependency loading in envoy_dependencies().

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -99,7 +99,7 @@ def _python_deps():
     )
     pip3_import(
         name = "fuzzing_py_deps",
-        requirements = "@bazel_rules_fuzzing//fuzzing:requirements.txt",
+        requirements = "@rules_fuzzing//fuzzing:requirements.txt",
     )
 
 # Envoy deps that rely on a first stage of dependency loading in envoy_dependencies().

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -8,11 +8,6 @@ def _python_deps():
     pip_repositories()
 
     pip3_import(
-        name = "fuzzing_py_deps",
-        requirements = "@rules_fuzzing//fuzzing:requirements.txt",
-    )
-
-    pip3_import(
         name = "config_validation_pip3",
         requirements = "@envoy//tools/config_validation:requirements.txt",
         extra_pip_args = ["--require-hashes"],
@@ -101,6 +96,10 @@ def _python_deps():
         # version = "1.15.0",
         # release_date = "2020-05-21"
         # use_category = ["test"],
+    )
+    pip3_import(
+        name = "fuzzing_py_deps",
+        requirements = "@bazel_rules_fuzzing//fuzzing:requirements.txt",
     )
 
 # Envoy deps that rely on a first stage of dependency loading in envoy_dependencies().

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -97,6 +97,10 @@ def _python_deps():
         # release_date = "2020-05-21"
         # use_category = ["test"],
     )
+    pip3_import(
+        name = "fuzzing_py_deps",
+        requirements = "@bazel_rules_fuzzing//fuzzing:requirements.txt",
+    )
 
 # Envoy deps that rely on a first stage of dependency loading in envoy_dependencies().
 def envoy_dependencies_extra():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -45,12 +45,12 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2019-10-10",
         use_category = ["build"],
     ),
-    bazel_rules_fuzzing = dict(
+    rules_fuzzing = dict(
         project_name = "Fuzzing Rules for Bazel",
         project_desc = "Bazel rules for fuzz tests",
         project_url = "https://github.com/bazelbuild/rules_fuzzing",
-        version = "7c12b01e2d951c22c2800854a5c727b3ab048816",
-        sha256 = "13c44744264ce4526c0650798edf4e177bdd17ab6b5a73963e15ce7c8df3363f",
+        version = "8cc9b2932a655231922bf4aa69057ccb055ed5de",
+        sha256 = "b61e078cbdc77509baa8f8e2892f7cd7f2afd16a94f745000500dab597729f91",
         strip_prefix = "rules_fuzzing-{version}",
         urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
         release_date = "2020-11-18",

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -45,6 +45,17 @@ REPOSITORY_LOCATIONS_SPEC = dict(
         release_date = "2019-10-10",
         use_category = ["build"],
     ),
+    bazel_rules_fuzzing = dict(
+        project_name = "Fuzzing Rules for Bazel",
+        project_desc = "Bazel rules for fuzz tests",
+        project_url = "https://github.com/bazelbuild/rules_fuzzing",
+        version = "7c12b01e2d951c22c2800854a5c727b3ab048816",
+        sha256 = "13c44744264ce4526c0650798edf4e177bdd17ab6b5a73963e15ce7c8df3363f",
+        strip_prefix = "rules_fuzzing-{version}",
+        urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/{version}.tar.gz"],
+        release_date = "2020-11-18",
+        use_category = ["test_only"],
+    ),
     envoy_build_tools = dict(
         project_name = "envoy-build-tools",
         project_desc = "Common build tools shared by the Envoy/UDPA ecosystem",


### PR DESCRIPTION
WIP

```
ERROR: /usr/local/google/home/asraa/.cache/bazel/_bazel_asraa/1eb5a935c6d685fad8c356a56ba4a215/external/envoy/bazel/foreign_cc/BUILD:79:21: error executing shell command: '/bin/bash -c #!/usr/bin/env bash
function cleanup_function() {
local ecode=$?
if [ $ecode -eq 0 ]; then
cleanup_on_success
else
cleanup_on_failure
fi
}
set -e
function cleanup_on_success() {
printf...' failed (Exit 1) bash failed: error executing command /bin/bash -c ... (remaining 1 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox

rules_foreign_cc: Build failed!
rules_foreign_cc: Keeping temp build directory  and dependencies directory  for debug.
rules_foreign_cc: Please note that the directories inside a sandbox are still cleaned unless you specify '--sandbox_debug' Bazel command line flag.

rules_foreign_cc: Printing build logs:

_____ BEGIN BUILD LOGS _____
Bazel external C/C++ Rules #0.0.8. Building library 'ares'
Environment:______________
BUILD_SCRIPT=bazel-out/k8-fastbuild/bin/external/envoy/bazel/foreign_cc/ares/logs/CMake_script.sh
EXT_BUILD_ROOT=/usr/local/google/home/asraa/.cache/bazel/_bazel_asraa/1eb5a935c6d685fad8c356a56ba4a215/sandbox/linux-sandbox/583/execroot/envoy
BUILD_LOG=bazel-out/k8-fastbuild/bin/external/envoy/bazel/foreign_cc/ares/logs/CMake.log
PWD=/usr/local/google/home/asraa/.cache/bazel/_bazel_asraa/1eb5a935c6d685fad8c356a56ba4a215/sandbox/linux-sandbox/583/execroot/envoy
LLVM_CONFIG=/opt/llvm/bin/llvm-config
CXX=clang++
CXXFLAGS=-stdlib=libc++
LDFLAGS=-stdlib=libc++
BAZEL_LINKOPTS=-lm:-pthread
TMPDIR=/tmp
EXT_BUILD_DEPS=/tmp/tmp.RL3ECO7iAU
BAZEL_LINKLIBS=-l%:libc++.a:-l%:libc++abi.a
BUILD_TMPDIR=/tmp/tmp.3tR7LBsPza
SHLVL=2
BAZEL_CXXOPTS=-stdlib=libc++
INSTALLDIR=/usr/local/google/home/asraa/.cache/bazel/_bazel_asraa/1eb5a935c6d685fad8c356a56ba4a215/sandbox/linux-sandbox/583/execroot/envoy/bazel-out/k8-fastbuild/bin/external/envoy/bazel/foreign_cc/ares
PATH=/usr/local/google/home/asraa/.cache/bazel/_bazel_asraa/1eb5a935c6d685fad8c356a56ba4a215/sandbox/linux-sandbox/583/execroot/envoy:/opt/llvm/bin:/usr/local/google/home/asraa/.local/bin:/usr/local/google/home/asraa/bin:/usr/local/google/home/asraa/google-cloud-sdk/bin:/usr/lib/google-golang/bin:/usr/local/buildtools/java/jdk/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/google/home/asraa/bin:/opt/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-18.04/bin
BAZEL_COMPILER=clang
CC=clang
_=/usr/bin/env
__________________________
-- The C compiler identification is Clang 10.0.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - failed
-- Check for working C compiler: /opt/llvm/bin/clang
-- Check for working C compiler: /opt/llvm/bin/clang - broken
CMake Error at /usr/share/cmake-3.18/Modules/CMakeTestCCompiler.cmake:66 (message):
  The C compiler

    "/opt/llvm/bin/clang"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: /tmp/tmp.3tR7LBsPza/CMakeFiles/CMakeTmp
    
    Run Build Command(s):/usr/bin/ninja cmTC_98e40 && [1/2] Building C object CMakeFiles/cmTC_98e40.dir/testCCompiler.c.o
    [2/2] Linking C executable cmTC_98e40
    FAILED: cmTC_98e40 
    : && /opt/llvm/bin/clang -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -fcolor-diagnostics -fno-omit-frame-pointer -no-canonical-prefixes -Wno-builtin-macro-redefined -D__DATE__="redacted" -D__TIMESTAMP__="redacted" -D__TIME__="redacted" -fPIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=fuzzer,address -fexceptions -stdlib=libc++   -rdynamic CMakeFiles/cmTC_98e40.dir/testCCompiler.c.o -o cmTC_98e40   && :
    /usr/bin/ld: CMakeFiles/cmTC_98e40.dir/testCCompiler.c.o: in function `main':
    testCCompiler.c:(.text.main[main]+0x0): multiple definition of `main'; /opt/llvm/lib/clang/10.0.0/lib/linux/libclang_rt.fuzzer-x86_64.a(fuzzer.o):/home/brian/src/final/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:18: first defined here
    /usr/bin/ld: /opt/llvm/lib/clang/10.0.0/lib/linux/libclang_rt.fuzzer-x86_64.a(fuzzer.o): in function `main':
    /home/brian/src/final/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:19: undefined reference to `LLVMFuzzerTestOneInput'
    clang: error: linker command failed with exit code 1 (use -v to see invocation)
    ninja: build stopped: subcommand failed.
    
    

  

  CMake will not be able to correctly generate this project.
Call Stack (most recent call first):
  CMakeLists.txt:11 (PROJECT)


-- Configuring incomplete, errors occurred!
See also "/tmp/tmp.3tR7LBsPza/CMakeFiles/CMakeOutput.log".
See also "/tmp/tmp.3tR7LBsPza/CMakeFiles/CMakeError.log".

_____ END BUILD LOGS _____
Printing build script:

_____ BEGIN BUILD SCRIPT _____
#!/usr/bin/env bash
function children_to_path() {
if [ -d $EXT_BUILD_DEPS/bin ]; then
local tools=$(find $EXT_BUILD_DEPS/bin -maxdepth 1 -mindepth 1)
for tool in $tools;
do
if  [[ -d "$tool" ]] || [[ -L "$tool" ]]; then
export PATH=$PATH:$tool
fi
done
fi
}
function replace_in_files() {
if [ -d "$1" ]; then
find -L $1 -type f   \( -name "*.pc" -or -name "*.la" -or -name "*-config" -or -name "*.cmake" \)   -exec sed -i 's@'"$2"'@'"$3"'@g' {} ';'
fi
}
printf ""
printf "Bazel external C/C++ Rules #0.0.8. Building library 'ares'\n"
printf ""
set -e

export EXT_BUILD_ROOT=$(pwd)
export BUILD_TMPDIR=$(mktemp -d)
export EXT_BUILD_DEPS=$(mktemp -d)
export INSTALLDIR=$EXT_BUILD_ROOT/bazel-out/k8-fastbuild/bin/external/envoy/bazel/foreign_cc/ares
export PATH="$EXT_BUILD_ROOT:$PATH"
mkdir -p $INSTALLDIR
printf "Environment:______________\n"
env
printf "__________________________\n"
children_to_path $EXT_BUILD_DEPS/bin
export PATH="$EXT_BUILD_DEPS/bin:$PATH"
cd $BUILD_TMPDIR
export INSTALL_PREFIX="ares"
CC="/opt/llvm/bin/clang" CXX="/opt/llvm/bin/clang" CFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -fcolor-diagnostics -fno-omit-frame-pointer -no-canonical-prefixes -Wno-builtin-macro-redefined -D__DATE__=\"redacted\" -D__TIMESTAMP__=\"redacted\" -D__TIME__=\"redacted\" -fPIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=fuzzer,address -fexceptions" CXXFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -fcolor-diagnostics -fno-omit-frame-pointer -stdlib=libc++ -no-canonical-prefixes -Wno-builtin-macro-redefined -D__DATE__=\"redacted\" -D__TIMESTAMP__=\"redacted\" -D__TIME__=\"redacted\" -fPIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=fuzzer,address -std=c++17" ASMFLAGS="-U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -fcolor-diagnostics -fno-omit-frame-pointer -no-canonical-prefixes -Wno-builtin-macro-redefined -D__DATE__=\"redacted\" -D__TIMESTAMP__=\"redacted\" -D__TIME__=\"redacted\" -fPIC -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=fuzzer,address -fexceptions" cmake -DCMAKE_AR="/usr/bin/ar" -DCMAKE_SHARED_LINKER_FLAGS="-shared -fuse-ld=/usr/bin/ld.gold -Wl,-no-as-needed -Wl,-z,relro,-z,now -B/opt/llvm/bin -lm -pthread -l:libc++.a -l:libc++abi.a -fuse-ld=lld -L/opt/llvm/lib -Wl,-rpath,/opt/llvm/lib -fuse-ld=lld -L/opt/llvm/lib -Wl,-rpath,/opt/llvm/lib -fuse-ld=lld -L/opt/llvm/lib -Wl,-rpath,/opt/llvm/lib -fsanitize=fuzzer,address" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=/usr/bin/ld.gold -Wl,-no-as-needed -Wl,-z,relro,-z,now -B/opt/llvm/bin -lm -pthread -l:libc++.a -l:libc++abi.a -fuse-ld=lld -L/opt/llvm/lib -Wl,-rpath,/opt/llvm/lib -fuse-ld=lld -L/opt/llvm/lib -Wl,-rpath,/opt/llvm/lib -fuse-ld=lld -L/opt/llvm/lib -Wl,-rpath,/opt/llvm/lib -fsanitize=fuzzer,address" -DCARES_SHARED="no" -DCARES_STATIC="on" -DCMAKE_CXX_COMPILER_FORCED="on" -DCMAKE_INSTALL_LIBDIR="lib" -DCMAKE_BUILD_TYPE="Bazel" -DCMAKE_PREFIX_PATH="$EXT_BUILD_DEPS" -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" -DCMAKE_RANLIB="" -GNinja $EXT_BUILD_ROOT/external/com_github_c_ares_c_ares
ninja -v
ninja -v install
cp -L -r --no-target-directory "$BUILD_TMPDIR/$INSTALL_PREFIX" "$INSTALLDIR" 
cp -L $EXT_BUILD_ROOT/external/com_github_c_ares_c_ares/src/lib/ares_dns.h $INSTALLDIR/include/ares_dns.h
replace_in_files $INSTALLDIR $BUILD_TMPDIR \${EXT_BUILD_DEPS}
replace_in_files $INSTALLDIR $EXT_BUILD_DEPS \${EXT_BUILD_DEPS}
mkdir -p $EXT_BUILD_ROOT/bazel-out/k8-fastbuild/bin/external/envoy/bazel/foreign_cc/copy_ares/ares
cp -L -r --no-target-directory "$INSTALLDIR" "$EXT_BUILD_ROOT/bazel-out/k8-fastbuild/bin/external/envoy/bazel/foreign_cc/copy_ares/ares" 
touch $EXT_BUILD_ROOT/bazel-out/k8-fastbuild/bin/external/envoy/bazel/foreign_cc/empty_ares.txt
cd $EXT_BUILD_ROOT
_____ END BUILD SCRIPT _____
rules_foreign_cc: Build script location: bazel-out/k8-fastbuild/bin/external/envoy/bazel/foreign_cc/ares/logs/CMake_script.sh
rules_foreign_cc: Build log location: bazel-out/k8-fastbuild/bin/external/envoy/bazel/foreign_cc/ares/logs/CMake.log

Target //test/common/common:base64_fuzz_test_experimental_run failed to build
```